### PR TITLE
Deprecated auto_ptr, move to unique_ptr as its only used internally

### DIFF
--- a/nodice/video.h
+++ b/nodice/video.h
@@ -38,7 +38,7 @@ namespace NoDice
     void update();
 
   private:
-    std::auto_ptr<VideoContext> m_context;
+    std::unique_ptr<VideoContext> m_context;
   };
 } // namespace NoDice
 


### PR DESCRIPTION
FTBFS on 17.10 ubuntu. Though there are some other warnings from libvmmlib, but the only error was auto_ptr usage.