### PR TITLE
Fix a few warnings -Werror=misleading-indentation in vmmlib

### DIFF
--- a/include/vmmlib/vector3.h
+++ b/include/vmmlib/vector3.h
@@ -517,7 +517,9 @@ T  Vector3< T >::normalize()
 { 
     const T l = length();
     if ( l == 0 ) 
+    {
         return 0; 
+    }
 
 	const T ll = 1.0 / l;
     x *= ll; 
@@ -535,7 +537,9 @@ T  Vector3< T >::normalize( float* source )
     Vector3< float >* a = ( Vector3< float >* ) source;
     const T l = a->length();
     if ( l == 0 ) 
+    {
         return 0;
+    }
     
 	const T ll = 1.0 / l;
     source[0] *= ll;

--- a/include/vmmlib/vector4.h
+++ b/include/vmmlib/vector4.h
@@ -510,7 +510,9 @@ T Vector4< T >::normalize()
 { 
     const T l = length(); 
     if ( l == 0 ) 
+    {
         return 0; 
+    }
 
 	const T ll = 1.0 / l;
     x *= ll; 


### PR DESCRIPTION
A few warnings in vmmlib, about misleading indentation. Looking upstream at vmmlib things have changed a bit and doesnt seem to give *.h when built the same way (though I could have built incorrectly)
http://paste.ubuntu.com/25155575/