### PR TITLE
Add asset search path

### DIFF
--- a/boilerplate/cpp
+++ b/boilerplate/cpp
@@ -1,21 +1,24 @@
 /**
  * @file xxx.cpp
  * @brief Implemntation of the xxx module.
+ */
+/*
+ * Copyright 2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
- * Copyright 2010 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ * This file is part of no-dice.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of Version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * No-dice is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "xxx.h"
 

--- a/boilerplate/h
+++ b/boilerplate/h
@@ -1,21 +1,24 @@
 /**
  * @file xxx.h
  * @brief Public interface of the xxx module.
+ */
+/*
+ * Copyright 2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
- * Copyright 2010 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ * This file is part of no-dice.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of Version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * No-dice is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef XXX_H
 #define XXX_H 1

--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,7 @@ AC_SUBST([GL_LIBS])
 
 # Crank the warnings level up to 11
 AC_SUBST([AM_CXXFLAGS],
-         ["-Wall -Wextra -Werror -pedantic -std=c++0x -D_GNU_SOURCE=1"])
+         ["-Wall -Wextra -Werror -pedantic -std=c++14 -D_GNU_SOURCE=1"])
 AC_DEFINE([NODICE_UNUSED],
           [__attribute__((unused))],[symbol is unused])
 

--- a/include/vmmlib/vector3.h
+++ b/include/vmmlib/vector3.h
@@ -77,13 +77,13 @@ public:
     void set( const float* values );
     void set( const double* values );
 
-	// create vector from a string containing a whitespace (or parameter 
-	// 'delimiter' ) delimited list of values.
-	// returns false if failed, true if it (seems to have) succeeded.
-	// PRE: string must contain at least 3 values, delimited by char delimiter.
-	bool set( const std::string& values, char delimiter = ' ' );
-	// PRE: vector must contain at least 3 strings with one value each
-	bool set( const std::vector< std::string >& values );
+    // create vector from a string containing a whitespace (or parameter 
+    // 'delimiter' ) delimited list of values.
+    // returns false if failed, true if it (seems to have) succeeded.
+    // PRE: string must contain at least 3 values, delimited by char delimiter.
+    bool set( const std::string& values, char delimiter = ' ' );
+    // PRE: vector must contain at least 3 strings with one value each
+    bool set( const std::vector< std::string >& values );
 
     const Vector3& operator=( T a ); 
     const Vector3& operator=( const Vector3& rhs ); 
@@ -170,15 +170,15 @@ public:
 
     T getMinComponent();
     T getMaxComponent();
-	
-	// uses the very bad cstdlib (rand()) rng. do NOT use for anything that needs
-	// real random numbers. also, srand() is not called, this is the duty of the 
-	// user. all random numbers are normalized to [0,1].
-	void randomize();
+    
+    // uses the very bad cstdlib (rand()) rng. do NOT use for anything that needs
+    // real random numbers. also, srand() is not called, this is the duty of the 
+    // user. all random numbers are normalized to [0,1].
+    void randomize();
 
-	// writes the values into param result, delimited by param 'delimiter'.
-	// returns false if it failed, true if it (seems to have) succeeded.
-	bool getString( std::string& result, const std::string& delimiter = " " ) const;
+    // writes the values into param result, delimited by param 'delimiter'.
+    // returns false if it failed, true if it (seems to have) succeeded.
+    bool getString( std::string& result, const std::string& delimiter = " " ) const;
 
     friend std::ostream& operator << ( std::ostream& os, const Vector3& v )
     {
@@ -372,9 +372,9 @@ template< typename T >
 bool
 Vector3< T >::set( const std::string& values, char delimiter )
 {
-	std::vector< std::string > tokens;
-	stringUtils::split( values, tokens, delimiter );
-	return set( tokens );
+    std::vector< std::string > tokens;
+    stringUtils::split( values, tokens, delimiter );
+    return set( tokens );
 }
 
 
@@ -387,19 +387,19 @@ template< typename T >
 bool
 Vector3< T >::set( const std::vector< std::string >& values )
 {
-	bool ok = true;
-	
-	if ( values.size() < 3 )
-		return false;
+    bool ok = true;
+    
+    if ( values.size() < 3 )
+    	return false;
 
-	std::vector< std::string >::const_iterator it 		= values.begin();
-	
-	for( size_t component = 0; ok && component < 3; ++component, ++it )
-	{
-			ok = stringUtils::fromString< T >( *it, xyz[ component ] );
-	}
-	
-	return ok;
+    std::vector< std::string >::const_iterator it 		= values.begin();
+    
+    for( size_t component = 0; ok && component < 3; ++component, ++it )
+    {
+    		ok = stringUtils::fromString< T >( *it, xyz[ component ] );
+    }
+    
+    return ok;
 }
 
 
@@ -454,7 +454,7 @@ const T& Vector3< T >::operator[]( size_t index ) const
 } 
 
 
-	
+    
 template < typename T > 
 T  Vector3< T >::length() const 
 { 
@@ -507,7 +507,7 @@ T  Vector3< T >::normalise()
 template < typename T > 
 T  Vector3< T >::normalise( float* source )
 {
-	return normalize( source );
+    return normalize( source );
 }
 
 
@@ -519,7 +519,7 @@ T  Vector3< T >::normalize()
     if ( l == 0 ) 
         return 0; 
 
-	const T ll = 1.0 / l;
+    const T ll = 1.0 / l;
     x *= ll; 
     y *= ll; 
     z *= ll; 
@@ -537,7 +537,7 @@ T  Vector3< T >::normalize( float* source )
     if ( l == 0 ) 
         return 0;
     
-	const T ll = 1.0 / l;
+    const T ll = 1.0 / l;
     source[0] *= ll;
     source[1] *= ll;
     source[2] *= ll;
@@ -1040,9 +1040,9 @@ template < typename T >
 void
 Vector3< T >::randomize()
 {
-	x = (double) rand() / RAND_MAX;
-	y = (double) rand() / RAND_MAX;
-	z = (double) rand() / RAND_MAX;
+    x = (double) rand() / RAND_MAX;
+    y = (double) rand() / RAND_MAX;
+    z = (double) rand() / RAND_MAX;
 }
 
 
@@ -1053,19 +1053,19 @@ template< typename T >
 bool
 Vector3< T >::getString( std::string& result, const std::string& delimiter ) const
 {
-	std::string tmp;
-	bool ok = true;
-	for( size_t component = 0; component < 3; ++component )
-	{
-		ok = stringUtils::toString< T >( xyz[ component ], tmp );
-		result += tmp;
-		result += delimiter;
-	}
-	return ok;
+    std::string tmp;
+    bool ok = true;
+    for( size_t component = 0; component < 3; ++component )
+    {
+    	ok = stringUtils::toString< T >( xyz[ component ], tmp );
+    	result += tmp;
+    	result += delimiter;
+    }
+    return ok;
 }
 
 
 
 } //namespace vmml
-	
+    
 #endif

--- a/include/vmmlib/vector4.h
+++ b/include/vmmlib/vector4.h
@@ -90,15 +90,15 @@ public:
     void set( const float* aa );
     void set( const double* aa );
 
-	void set( const Vector3< T >& xyz_, const T& w_ );
+    void set( const Vector3< T >& xyz_, const T& w_ );
 
-	// create vector from a string containing a whitespace (or parameter 
-	// 'delimiter' ) delimited list of values.
-	// returns false if failed, true if it (seems to have) succeeded.
-	// PRE: string must contain at least 4 values, delimited by char delimiter.
-	bool set( const std::string& values, char delimiter = ' ' );
-	// PRE: vector must contain at least 4 strings with one value each
-	bool set( const std::vector< std::string >& values );
+    // create vector from a string containing a whitespace (or parameter 
+    // 'delimiter' ) delimited list of values.
+    // returns false if failed, true if it (seems to have) succeeded.
+    // PRE: string must contain at least 4 values, delimited by char delimiter.
+    bool set( const std::string& values, char delimiter = ' ' );
+    // PRE: vector must contain at least 4 strings with one value each
+    bool set( const std::vector< std::string >& values );
 
     const Vector4& operator=( T aa ); 
     const Vector4& operator=( const Vector3<T>& aa ); 
@@ -119,7 +119,7 @@ public:
     Vector4 getNormalized() const;
     
     /** Return normalized Vector3, using only xyz coordinates */
-	Vector3 <T> getNormalizedVector3() const;
+    Vector3 <T> getNormalizedVector3() const;
 
     // vector/scalar operations
     Vector4 operator+( const T aa ) const;
@@ -158,32 +158,32 @@ public:
 
     T getMinComponent();
     T getMaxComponent();
-	
-	// uses the very bad cstdlib (rand()) rng. do NOT use for anything that needs
-	// real random numbers. also, srand() is not called, this is the duty of the 
-	// user. all random numbers are normalized to [0,1].
-	void randomize();
+    
+    // uses the very bad cstdlib (rand()) rng. do NOT use for anything that needs
+    // real random numbers. also, srand() is not called, this is the duty of the 
+    // user. all random numbers are normalized to [0,1].
+    void randomize();
 
-	// sphere functions
-	inline Vector3< T > projectPointOntoSphere( const Vector3< T >& point ) const;
-	// returns a negative distance if the point lies in the sphere
-	inline T getDistanceToSphere( const Vector3< T >& point ) const;
+    // sphere functions
+    inline Vector3< T > projectPointOntoSphere( const Vector3< T >& point ) const;
+    // returns a negative distance if the point lies in the sphere
+    inline T getDistanceToSphere( const Vector3< T >& point ) const;
 
     inline Vector3< T >& getSphereCenter();
     inline const Vector3< T >& getSphereCenter() const;
     
 
-	// plane functions
-	inline Vector3< T > projectPointOntoPlane( const Vector3< T >& point ) const;
+    // plane functions
+    inline Vector3< T > projectPointOntoPlane( const Vector3< T >& point ) const;
     // this normalizes the vector3 consisting of the first three 
     // coordinates, and leaves the fourth as is.
-	inline T getDistanceToPlane( const Vector3< T >& point ) const;
+    inline T getDistanceToPlane( const Vector3< T >& point ) const;
     void normalizePlane();
     
 
-	// writes the values into param result, delimited by param 'delimiter'.
-	// returns false if it failed, true if it (seems to have) succeeded.
-	bool getString( std::string& result, const std::string& delimiter = " " ) const;
+    // writes the values into param result, delimited by param 'delimiter'.
+    // returns false if it failed, true if it (seems to have) succeeded.
+    bool getString( std::string& result, const std::string& delimiter = " " ) const;
 
     friend std::ostream& operator << ( std::ostream& os, const Vector4& v )
     {
@@ -365,10 +365,10 @@ template < typename T >
 void
 Vector4< T >::set( const Vector3< T >& xyz_, const T& w_ )
 {
-	x = xyz_.x;
-	y = xyz_.y;
-	z = xyz_.z;
-	w = w_;
+    x = xyz_.x;
+    y = xyz_.y;
+    z = xyz_.z;
+    w = w_;
 }
 
 
@@ -381,9 +381,9 @@ template< typename T >
 bool
 Vector4< T >::set( const std::string& values, char delimiter )
 {
-	std::vector< std::string > tokens;
-	stringUtils::split( values, tokens, delimiter );
-	return set( tokens );
+    std::vector< std::string > tokens;
+    stringUtils::split( values, tokens, delimiter );
+    return set( tokens );
 }
 
 
@@ -396,19 +396,19 @@ template< typename T >
 bool
 Vector4< T >::set( const std::vector< std::string >& values )
 {
-	bool ok = true;
-	
-	if ( values.size() < 4 )
-		return false;
+    bool ok = true;
+    
+    if ( values.size() < 4 )
+    	return false;
 
-	std::vector< std::string >::const_iterator it 		= values.begin();
-	
-	for( size_t component = 0; ok && component < 4; ++component, ++it )
-	{
-			ok = stringUtils::fromString< T >( *it, xyzw[ component ] );
-	}
-	
-	return ok;
+    std::vector< std::string >::const_iterator it 		= values.begin();
+    
+    for( size_t component = 0; ok && component < 4; ++component, ++it )
+    {
+    		ok = stringUtils::fromString< T >( *it, xyzw[ component ] );
+    }
+    
+    return ok;
 }
 
 
@@ -474,7 +474,7 @@ const T& Vector4< T >::operator[]( size_t index ) const
 } 
 
 
-	
+    
 template < typename T > 
 T  Vector4< T >::length() const 
 { 
@@ -500,7 +500,7 @@ T  Vector4< T >::lengthSquared() const
 template < typename T > 
 T Vector4< T >::normalise()
 { 
-	return normalize();
+    return normalize();
 } 
 
 
@@ -512,7 +512,7 @@ T Vector4< T >::normalize()
     if ( l == 0 ) 
         return 0; 
 
-	const T ll = 1.0 / l;
+    const T ll = 1.0 / l;
     x *= ll; 
     y *= ll; 
     z *= ll; 
@@ -559,7 +559,7 @@ Vector3< T >
 Vector4< T >::getNormalizedVector3() const
 {
     const T len = sqrt( x * x + y * y + z * z );
-	const T ilen = 1.0 / len;
+    const T ilen = 1.0 / len;
     return Vector3<T>( x * ilen, y * ilen, z * ilen );
 }
 
@@ -910,7 +910,7 @@ inline bool Vector4< float >::isAkin( const Vector4& rhs, const float& delta ) c
 
 template < typename T > 
 void Vector4< T >::invert() 
-{	
+{
     x = -x; 
     y = -y; 
     z = -z; 
@@ -945,8 +945,8 @@ template < typename T >
 inline Vector3< T >
 Vector4< T >::projectPointOntoSphere( const Vector3< T >& point ) const
 {
-	const Vector3< T >& center_ = *reinterpret_cast< const Vector3< T >* >( &x );
-	return center_ + ( point - center_ ).normalize() * radius; 
+    const Vector3< T >& center_ = *reinterpret_cast< const Vector3< T >* >( &x );
+    return center_ + ( point - center_ ).normalize() * radius; 
 }
 
 
@@ -955,8 +955,8 @@ template < typename T >
 inline T
 Vector4< T >::getDistanceToSphere( const Vector3< T >& point ) const
 {
-	const Vector3< T >& center_ = *reinterpret_cast< const Vector3< T >* >( &x );
-	return ( point - center_ ).length() - radius;
+    const Vector3< T >& center_ = *reinterpret_cast< const Vector3< T >* >( &x );
+    return ( point - center_ ).length() - radius;
 }
 
 
@@ -982,8 +982,8 @@ template < typename T >
 inline Vector3< T >
 Vector4< T >::projectPointOntoPlane( const Vector3< T >& point ) const
 {
-	const Vector3< T >& normal_ = *reinterpret_cast< const Vector3< T >* >( &x );
-	return point - ( normal_ * getDistanceToPlane( point ) );
+    const Vector3< T >& normal_ = *reinterpret_cast< const Vector3< T >* >( &x );
+    return point - ( normal_ * getDistanceToPlane( point ) );
 }
 
 
@@ -992,7 +992,7 @@ template < typename T >
 inline T
 Vector4< T >::getDistanceToPlane( const Vector3< T >& point ) const
 {
-	const Vector3< T >& normal_ = *reinterpret_cast< const Vector3< T >* >( &x );
+    const Vector3< T >& normal_ = *reinterpret_cast< const Vector3< T >* >( &x );
     return normal_.dot( point ) + distance;
 }
 
@@ -1002,10 +1002,10 @@ template < typename T >
 void
 Vector4< T >::randomize()
 {
-	x = (double) rand() / RAND_MAX;
-	y = (double) rand() / RAND_MAX;
-	z = (double) rand() / RAND_MAX;
-	w = (double) rand() / RAND_MAX;
+    x = (double) rand() / RAND_MAX;
+    y = (double) rand() / RAND_MAX;
+    z = (double) rand() / RAND_MAX;
+    w = (double) rand() / RAND_MAX;
 }
 
 
@@ -1016,15 +1016,15 @@ template< typename T >
 bool
 Vector4< T >::getString( std::string& result, const std::string& delimiter ) const
 {
-	std::string tmp;
-	bool ok = true;
-	for( size_t component = 0; component < 4; ++component )
-	{
-		ok = stringUtils::toString< T >( xyzw[ component ], tmp );
-		result += tmp;
-		result += delimiter;
-	}
-	return ok;
+    std::string tmp;
+    bool ok = true;
+    for( size_t component = 0; component < 4; ++component )
+    {
+    	ok = stringUtils::toString< T >( xyzw[ component ], tmp );
+    	result += tmp;
+    	result += delimiter;
+    }
+    return ok;
 }
 
 

--- a/nodice/Makefile.am
+++ b/nodice/Makefile.am
@@ -56,6 +56,7 @@ no_dice_CPPFLAGS = \
 	-I$(top_srcdir)/include \
 	-DHAVE_GL_VERTEX_BUFFERS \
 	-DDATA_DIR=\"${pkgdatadir}\" \
+	-DNODICE_SRC_DIR=\"${abs_top_srcdir}\" \
 	$(SDL_CFLAGS) \
 	$(FREETYPE_CFLAGS) \
 	$(GL_CFLAGS)

--- a/nodice/Makefile.am
+++ b/nodice/Makefile.am
@@ -41,6 +41,7 @@ libnodice_la_SOURCES = \
 	d12.h              d12.cpp \
 	d20.h              d20.cpp \
 	font.h             font.cpp \
+	fontcache.h        fontcache.cpp \
 	gamestate.h        gamestate.cpp \
 	introstate.h       introstate.cpp \
 	maths.h \
@@ -62,15 +63,17 @@ libnodice_la_CPPFLAGS = \
 	$(FREETYPE_CFLAGS) \
 	$(GL_CFLAGS)
 
+libnodice_la_LIBADD = \
+	$(SDL_LIBS) \
+	$(FREETYPE_LIBS) \
+	$(GL_LIBS)
+
 no_dice_SOURCES = \
 	main.cpp
 
 no_dice_CPPFLAGS = $(libnodice_la_CPPFLAGS)
 
 no_dice_LDADD = \
-	libnodice.la \
-	$(SDL_LIBS) \
-	$(FREETYPE_LIBS) \
-	$(GL_LIBS)
+	libnodice.la
 
 

--- a/nodice/app.cpp
+++ b/nodice/app.cpp
@@ -65,13 +65,14 @@ NoDice::App::SdlInit::
  * The App object takes care of initializing the even system.
  */
 NoDice::App::
-App(NoDice::Config const* config)
+App(NoDice::Config* config)
 : config_(config)
 , sdl_init_()
 , video_(config)
+, font_cache_(config)
 {
 	std::srand(std::time(NULL));
-	pushGameState(GameStatePtr(new IntroState(config_, video_)));
+	push_game_state(GameStatePtr(new IntroState(this, video_)));
 }
 
 
@@ -173,16 +174,30 @@ run()
 
 
 void NoDice::App::
-pushGameState(GameStatePtr state)
+push_game_state(GameStatePtr state)
 {
 	state_stack_.push(state);
 }
 
 
 void NoDice::App::
-popGameState()
+pop_game_state()
 {
 	state_stack_.pop();
+}
+
+
+NoDice::Config& NoDice::App::
+config()
+{
+  return *config_;
+}
+
+
+NoDice::FontCache& NoDice::App::
+font_cache()
+{
+  return font_cache_;
 }
 
 

--- a/nodice/app.h
+++ b/nodice/app.h
@@ -1,26 +1,28 @@
 /**
  * @file nodice/app.h
  * @brief Public interface of the nodice/app module.
+ */
+/*
+ * Copyright 2009,2010,2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
- * Copyright 2009, 2010 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ * This file is part of no-dice.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of Version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * No-dice is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef NODICE_APP_H
 #define NODICE_APP_H 1
 
-#include "nodice/config.h"
 #include "nodice/gamestate.h"
 #include "nodice/video.h"
 #include <stack>
@@ -37,14 +39,19 @@ namespace NoDice
   class App
   {
   public:
-    App(const Config& config);
+    explicit
+    App(Config const* config);
 
     ~App();
 
-    int run();
+    int
+    run();
 
-		void pushGameState(GameStatePtr state);
-		void popGameState();
+    void
+    pushGameState(GameStatePtr state);
+
+    void
+    popGameState();
 
   private:
     /** @brief A special RAII object for SDL initialization and teardown. */
@@ -55,12 +62,12 @@ namespace NoDice
     };
 
   private:
-  	typedef std::stack<GameStatePtr, std::vector<GameStatePtr> > StateStack;
+    typedef std::stack<GameStatePtr, std::vector<GameStatePtr>> StateStack;
 
-    Config     m_config;
-    SdlInit    m_sdlInit;
-    Video      m_video;
-    StateStack m_stateStack;
+    Config const*  config_;
+    SdlInit        sdl_init_;
+    Video          video_;
+    StateStack     state_stack_;
   };
 
 } // namespace NoDice

--- a/nodice/app.h
+++ b/nodice/app.h
@@ -23,6 +23,7 @@
 #ifndef NODICE_APP_H
 #define NODICE_APP_H 1
 
+#include "nodice/fontcache.h"
 #include "nodice/gamestate.h"
 #include "nodice/video.h"
 #include <stack>
@@ -40,7 +41,7 @@ namespace NoDice
   {
   public:
     explicit
-    App(Config const* config);
+    App(Config * config);
 
     ~App();
 
@@ -48,10 +49,16 @@ namespace NoDice
     run();
 
     void
-    pushGameState(GameStatePtr state);
+    push_game_state(GameStatePtr state);
 
     void
-    popGameState();
+    pop_game_state();
+
+    Config&
+    config();
+
+    FontCache&
+    font_cache();
 
   private:
     /** @brief A special RAII object for SDL initialization and teardown. */
@@ -64,9 +71,10 @@ namespace NoDice
   private:
     typedef std::stack<GameStatePtr, std::vector<GameStatePtr>> StateStack;
 
-    Config const*  config_;
+    Config*        config_;
     SdlInit        sdl_init_;
     Video          video_;
+    FontCache      font_cache_;
     StateStack     state_stack_;
   };
 

--- a/nodice/board.cpp
+++ b/nodice/board.cpp
@@ -31,56 +31,56 @@ namespace
 
 
 NoDice::Board::
-Board(const NoDice::Config& config)
-: m_config(config)
-, m_state(state_idle)
+Board(NoDice::Config const* config)
+: config_(config)
+, state_(state_idle)
 {
-  for (int y = 0; y < m_config.boardSize(); ++y)
+  for (int y = 0; y < config_->board_size(); ++y)
   {
-    for (int x = 0; x < m_config.boardSize(); ++x)
+    for (int x = 0; x < config_->board_size(); ++x)
     {
-      m_objects.push_back(ObjectPtr(new Object(NoDice::chooseAShape(),
+      objects_.push_back(ObjectPtr(new Object(NoDice::chooseAShape(),
                                      Vector3f(x * 2.0f, y * 2.0f, 0.0f))));
     }
   }
-  if (findWins().size() > 0)
+  if (find_wins().size() > 0)
   {
-    m_state = state_removing;
+    state_ = state_removing;
   }
 }
 
 
 NoDice::ObjectPtr&  NoDice::Board::
 at(const NoDice::Vector2i& p)
-{ return m_objects[p.x + p.y * m_config.boardSize()]; }
+{ return objects_[p.x + p.y * config_->board_size()]; }
 
 
 const NoDice::ObjectPtr&  NoDice::Board::
 at(int x, int y) const
-{ return m_objects[x + y * m_config.boardSize()]; }
+{ return objects_[x + y * config_->board_size()]; }
 
 
 void NoDice::Board::
 update()
 {
-  for (auto it = m_objects.begin(); it != m_objects.end(); ++it)
+  for (auto it = objects_.begin(); it != objects_.end(); ++it)
   {
     (*it)->update();
   }
 
-  switch (m_state)
+  switch (state_)
   {
     case state_swapping:
     {
-      m_swapStep += swap_step;
-      if (m_swapStep > swap_factor)
+      swap_step_ += swap_step;
+      if (swap_step_ > swap_factor)
       {
-        at(m_swapObj[0]).swap(at(m_swapObj[1]));
-        for (auto it = m_objects.begin(); it != m_objects.end(); ++it)
+        at(swap_obj_[0]).swap(at(swap_obj_[1]));
+        for (auto it = objects_.begin(); it != objects_.end(); ++it)
         {
           (*it)->setVelocity(Vector3f(0.0f, 0.0f, 0.0f));
         }
-        m_state = state_idle;
+        state_ = state_idle;
       }
       break;
     }
@@ -88,17 +88,17 @@ update()
     case state_removing:
     {
       // Wait until all disappearing is finished.
-      for (auto it = m_removalQueue.begin(); it != m_removalQueue.end(); ++it)
+      for (auto it = removal_queue_.begin(); it != removal_queue_.end(); ++it)
       {
         if (!at(*it)->hasDisappeared())
           return;
       }
 
-      m_state = state_falling;
-      for (int x = 0; x < m_config.boardSize(); ++x)
+      state_ = state_falling;
+      for (int x = 0; x < config_->board_size(); ++x)
       {
         int drop = 0;
-        for (int y = 0; y < m_config.boardSize(); ++y)
+        for (int y = 0; y < config_->board_size(); ++y)
         {
           if (at(x, y)->hasDisappeared())
           {
@@ -107,46 +107,46 @@ update()
           else if (drop > 0)
           {
             at(x, y)->startFalling(Vector3f(2.0f * x, 2.0f * (y - drop), 0.0f));
-            m_fallingQueue.push_back(std::make_pair(Vector2i(x, y),
+            falling_queue_.push_back(std::make_pair(Vector2i(x, y),
                                                     Vector2i(x, y - drop)));
           }
         }
         for (int y = 0; y < drop; ++y)
         {
-          int new_y = m_config.boardSize() - y - 1;
-          m_createQueue.push_back(Vector2i(x, new_y));
+          int new_y = config_->board_size() - y - 1;
+          create_queue_.push_back(Vector2i(x, new_y));
         }
       }
-      m_removalQueue.clear();
+      removal_queue_.clear();
       break;
     }
 
     case state_falling:
     {
       // Wait until all falling is finished.
-      for (auto it = m_fallingQueue.begin(); it != m_fallingQueue.end(); ++it)
+      for (auto it = falling_queue_.begin(); it != falling_queue_.end(); ++it)
       {
         if (at((*it).first)->isFalling())
           return;
       }
 
       // Percolate removed jobbies out
-      for (auto it = m_fallingQueue.begin(); it != m_fallingQueue.end(); ++it)
+      for (auto it = falling_queue_.begin(); it != falling_queue_.end(); ++it)
       {
         at((*it).first).swap(at((*it).second));
         ObjectPtr().swap(at((*it).first));
       }
-      m_fallingQueue.clear();
+      falling_queue_.clear();
 
       // Fill in the blanks.
-      for (auto it = m_createQueue.begin(); it != m_createQueue.end(); ++it)
+      for (auto it = create_queue_.begin(); it != create_queue_.end(); ++it)
       {
         at(*it) = ObjectPtr(new Object(NoDice::chooseAShape(),
                             Vector3f((*it).x * 2.0f, (*it).y * 2.0f, 0.0f)));
       }
-      m_createQueue.clear();
+      create_queue_.clear();
 
-      m_state = state_idle;
+      state_ = state_idle;
       break;
     }
 
@@ -161,9 +161,9 @@ draw() const
 {
   glMatrixMode(GL_MODELVIEW);
   glPushMatrix();
-  for (int y = 0; y < m_config.boardSize(); ++y)
+  for (int y = 0; y < config_->board_size(); ++y)
   {
-    for (int x = 0; x < m_config.boardSize(); ++x)
+    for (int x = 0; x < config_->board_size(); ++x)
     {
       at(x, y)->draw();
     }
@@ -173,10 +173,10 @@ draw() const
 
 
 void NoDice::Board::
-startSwap(NoDice::Vector2i pos1, NoDice::Vector2i pos2)
+start_swap(NoDice::Vector2i pos1, NoDice::Vector2i pos2)
 {
-  m_swapObj[0] = pos1;
-  m_swapObj[1] = pos2;
+  swap_obj_[0] = pos1;
+  swap_obj_[1] = pos2;
   ObjectPtr obj1 = at(pos1.x, pos1.y);
   ObjectPtr obj2 = at(pos2.x, pos2.y);
   obj1->setVelocity(Vector3f(float(pos2.x-pos1.x) / swap_factor,
@@ -185,29 +185,29 @@ startSwap(NoDice::Vector2i pos1, NoDice::Vector2i pos2)
   obj2->setVelocity(Vector3f(float(pos1.x-pos2.x) / swap_factor,
                              float(pos1.y-pos2.y) / swap_factor,
                              0.0f));
-  m_swapStep = 0.0f;
-  m_state = state_swapping;
+  swap_step_ = 0.0f;
+  state_ = state_swapping;
 }
 
 
 void NoDice::Board::
-unSwap()
+un_swap()
 {
-  startSwap(m_swapObj[1], m_swapObj[0]);
+  start_swap(swap_obj_[1], swap_obj_[0]);
 }
 
 
 bool NoDice::Board::
-isSwapping() const
+is_swapping() const
 {
-  return m_state == state_swapping;
+  return state_ == state_swapping;
 }
 
 
 bool NoDice::Board::
-isReplacing() const
+is_replacing() const
 {
-  return m_state == state_removing || m_state == state_falling;
+  return state_ == state_removing || state_ == state_falling;
 }
 
 
@@ -215,20 +215,20 @@ isReplacing() const
  * Looks for 3 (or more) matching objects in a row, horizontal or vertical.
  */
 NoDice::ObjectBrace NoDice::Board::
-findWins()
+find_wins()
 {
   ObjectBrace matches;
 
   // check for 3-or-more-in-a-row
-  for (int y = 0; y < m_config.boardSize(); ++y)
+  for (int y = 0; y < config_->board_size(); ++y)
   {
     int x = 0;
-    while (x <  m_config.boardSize()-2)
+    while (x <  config_->board_size()-2)
     {
       int count = 0;
       const ObjectPtr& obj = at(x, y);
       auto type = obj->type();
-      for (int i = x; i < m_config.boardSize(); ++i)
+      for (int i = x; i < config_->board_size(); ++i)
       {
         if (type == at(i, y)->type())
         {
@@ -243,7 +243,7 @@ findWins()
         for (int i = 0; i < count; ++i)
         {
           const Vector2i p(x+i, y);
-          m_removalQueue.push_back(p);
+          removal_queue_.push_back(p);
           ObjectPtr& o = at(p);
           brace.push_back(o);
           o->startDisappearing();
@@ -259,15 +259,15 @@ findWins()
   }
 
   // check for 3-in-a-column
-  for (int x = 0; x < m_config.boardSize(); ++x)
+  for (int x = 0; x < config_->board_size(); ++x)
   {
     int y = 0;
-    while (y <  m_config.boardSize()-2)
+    while (y <  config_->board_size()-2)
     {
       int count = 0;
       const ObjectPtr& obj = at(x, y);
       auto type = obj->type();
-      for (int i = y; i < m_config.boardSize(); ++i)
+      for (int i = y; i < config_->board_size(); ++i)
       {
         if (type == at(x, i)->type())
         {
@@ -282,7 +282,7 @@ findWins()
         for (int i = 0; i < count; ++i)
         {
           const Vector2i p(x, y+i);
-          m_removalQueue.push_back(p);
+          removal_queue_.push_back(p);
           ObjectPtr& o = at(p);
           brace.push_back(o);
           o->startDisappearing();
@@ -298,7 +298,7 @@ findWins()
   }
 
   if (matches.size() > 0)
-    m_state = state_removing;
+    state_ = state_removing;
 
   return matches;
 }

--- a/nodice/board.h
+++ b/nodice/board.h
@@ -1,26 +1,28 @@
 /**
  * @file nodice/board.h
  * @brief Public interface of the nodice/board module.
+ */
+/*
+ * Copyright 2010,2011,2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
- * Copyright 2010, 2011 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ * This file is part of no-dice.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of Version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * No-dice is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef NODICE_BOARD_H
 #define NODICE_BOARD_H 1
 
-#include "nodice/config.h"
 #include "nodice/maths.h"
 #include "nodice/object.h"
 #include <utility>
@@ -37,19 +39,31 @@ namespace NoDice
   class Board
   {
   public:
-    Board(const Config& config);
+    Board(Config const* config);
 
-    const ObjectPtr& at(int x, int y) const;
+    ObjectPtr const&
+    at(int x, int y) const;
 
-    void update();
-    void draw() const;
+    void
+    update();
 
-    void startSwap(Vector2i objPos1, Vector2i objPos2);
-    void unSwap();
-    bool isSwapping() const;
-    bool isReplacing() const;
+    void
+    draw() const;
 
-    ObjectBrace findWins();
+    void
+    start_swap(Vector2i objPos1, Vector2i objPos2);
+
+    void
+    un_swap();
+
+    bool
+    is_swapping() const;
+
+    bool
+    is_replacing() const;
+
+    ObjectBrace
+    find_wins();
 
   private:
     ObjectPtr& at(const Vector2i& point);
@@ -68,14 +82,14 @@ namespace NoDice
       state_falling
     };
 
-    Config       m_config;
-    ObjectBag    m_objects;
-    State        m_state;
-    float        m_swapStep;
-    Vector2i     m_swapObj[2];
-    RemovalQueue m_removalQueue;
-    FallingQueue m_fallingQueue;
-    CreateQueue  m_createQueue;
+    Config const*  config_;
+    ObjectBag      objects_;
+    State          state_;
+    float          swap_step_;
+    Vector2i       swap_obj_[2];
+    RemovalQueue   removal_queue_;
+    FallingQueue   falling_queue_;
+    CreateQueue    create_queue_;
   };
 } // namespace NoDice
 

--- a/nodice/config.cpp
+++ b/nodice/config.cpp
@@ -107,13 +107,13 @@ namespace
  */
 NoDice::Config::
 Config(int argc, char* argv[])
-: isDirty_(false)
-, isDebugMode_(false)
-, isFullscreen_(false)
-, isSmallWindow_(false)
-, screenWidth_(640)
-, screenHeight_(480)
-, boardSize_(8)
+: is_dirty_(false)
+, is_debug_mode_(false)
+, is_fullscreen_(false)
+, is_small_window_(false)
+, screen_width_(640)
+, screen_height_(480)
+, board_size_(8)
 , asset_search_path_(get_asset_search_path())
 {
   for (int i = 0; i < argc; ++i)
@@ -125,19 +125,19 @@ Config(int argc, char* argv[])
       {
         case 'd':
         {
-          isDebugMode_ = true;
+          is_debug_mode_ = true;
           break;
         }
 
         case 'f':
         {
-          isFullscreen_ = true;
+          is_fullscreen_ = true;
           break;
         }
 
         case 'w':
         {
-          isSmallWindow_ = true;
+          is_small_window_ = true;
           break;
         }
 
@@ -165,74 +165,74 @@ NoDice::Config::
 
 
 bool NoDice::Config::
-isDebugMode() const
+is_debug_mode() const
 {
-  return isDebugMode_;
+  return is_debug_mode_;
 }
 
 
 bool NoDice::Config::
-isFullscreen() const
+is_fullscreen() const
 {
-  return isFullscreen_;
+  return is_fullscreen_;
 }
 
 
 bool NoDice::Config::
-isSmallWindow() const
+is_small_window() const
 {
-  return isSmallWindow_;
+  return is_small_window_;
 }
 
 
 int NoDice::Config::
-screenWidth() const
+screen_width() const
 {
-  return screenWidth_;
+  return screen_width_;
 }
 
 
 void NoDice::Config::
-setScreenWidth(int w)
+set_screen_width(int w)
 {
-  if (screenWidth_ != w)
+  if (screen_width_ != w)
   {
-    screenWidth_ = w;
-    setDirty();
+    screen_width_ = w;
+    set_dirty();
   }
 }
 
 
 int NoDice::Config::
-screenHeight() const
+screen_height() const
 {
-  return screenHeight_;
+  return screen_height_;
 }
 
 
 void NoDice::Config::
-setScreenHeight(int h)
+set_screen_height(int h)
 {
-  if (screenHeight_ != h)
+  if (screen_height_ != h)
   {
-    screenHeight_ = h;
-    setDirty();
+    screen_height_ = h;
+    set_dirty();
   }
 }
 
 
 int NoDice::Config::
-boardSize() const
-{ return boardSize_; }
+board_size() const
+{ return board_size_; }
 
 
 void NoDice::Config::
-setBoardSize(int size)
+set_board_size(int size)
 {
-  if (boardSize_ != size)
+  if (board_size_ != size)
   {
-    boardSize_ = size;
-    setDirty();
+    board_size_ = size;
+    set_dirty();
   }
 }
 
@@ -245,7 +245,7 @@ asset_search_path() const
 
 
 void NoDice::Config::
-setDirty()
+set_dirty()
 {
-  isDirty_ = true;
+  is_dirty_ = true;
 }

--- a/nodice/config.cpp
+++ b/nodice/config.cpp
@@ -22,8 +22,13 @@
  */
 #include "nodice/config.h"
 
+#include <cstdlib>
 #include <cstring>
 #include <iostream>
+
+#ifndef NODICE_SRC_DIR
+# define NODICE_SRC_DIR "./"
+#endif
 
 
 namespace
@@ -48,6 +53,45 @@ namespace
     }
     return NULL;
   }
+
+
+  static std::vector<std::string>
+  split_path_on_colon(std::string const& path)
+  {
+    std::vector<std::string> v;
+    std::string::size_type p = 0;
+    std::string::size_type q = path.find(':', p);
+    while (true)
+    {
+      std::string s = path.substr(p, q - p);
+      if (s.length() > 0)
+        v.push_back(s);
+      if (q == std::string::npos)
+        break;
+      p = q+1;
+      q = path.find(':', p);
+    }
+    return v;
+  }
+
+  static std::vector<std::string>
+  get_asset_search_path()
+  {
+    std::vector<std::string> search_path = {
+      NODICE_SRC_DIR "/assets"
+    };
+
+    char* env = getenv("NODICE_ASSET_PATH");
+    if (env)
+    {
+      for (auto const& p: split_path_on_colon(env))
+      {
+        search_path.push_back(p);
+      }
+    }
+
+    return search_path;
+  }
 }
 
 
@@ -70,6 +114,7 @@ Config(int argc, char* argv[])
 , screenWidth_(640)
 , screenHeight_(480)
 , boardSize_(8)
+, asset_search_path_(get_asset_search_path())
 {
   for (int i = 0; i < argc; ++i)
   {
@@ -189,6 +234,13 @@ setBoardSize(int size)
     boardSize_ = size;
     setDirty();
   }
+}
+
+
+std::vector<std::string> const& NoDice::Config::
+asset_search_path() const
+{
+  return asset_search_path_;
 }
 
 

--- a/nodice/config.cpp
+++ b/nodice/config.cpp
@@ -1,21 +1,24 @@
 /**
  * @file nodice/config.cpp
  * @brief Implemntation of the nodice/config module.
+ */
+/*
+ * Copyright 2009-2013 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
- * Copyright 2009, 2010 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ * This file is part of no-dice.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of Version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * No-dice is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "nodice/config.h"
 
@@ -25,26 +28,26 @@
 
 namespace
 {
-	/**
-	 * Tries to extract an option argument.
-	 * @param[in]  a1
-	 * @param[in]  a2
-	 * @param[out] index
-	 */
-	static const char*
-	getarg(const char* a1, const char* a2, int& index)
-	{
-		if (std::strlen(a1) > 0)
-		{
-			return a1;
-		}
-		if (a2)
-		{
-			++index;
-			return a2;
-		}
-		return NULL;
-	}
+  /**
+   * Tries to extract an option argument.
+   * @param[in]  a1
+   * @param[in]  a2
+   * @param[out] index
+   */
+  static char const*
+  getarg(char const* a1, char const* a2, int& index)
+  {
+    if (std::strlen(a1) > 0)
+    {
+      return a1;
+    }
+    if (a2)
+    {
+      ++index;
+      return a2;
+    }
+    return NULL;
+  }
 }
 
 
@@ -60,53 +63,53 @@ namespace
  */
 NoDice::Config::
 Config(int argc, char* argv[])
-: m_isDirty(false)
-, m_isDebugMode(false)
-, m_isFullscreen(false)
-, m_isSmallWindow(false)
-, m_screenWidth(640)
-, m_screenHeight(480)
-, m_boardSize(8)
+: isDirty_(false)
+, isDebugMode_(false)
+, isFullscreen_(false)
+, isSmallWindow_(false)
+, screenWidth_(640)
+, screenHeight_(480)
+, boardSize_(8)
 {
-	for (int i = 0; i < argc; ++i)
-	{
-		if (*argv[i] == '-')
-		{
-			char c = *(argv[i] + 1);
-			switch (c)
-			{
-				case 'd':
-				{
-					m_isDebugMode = true;
-					break;
-				}
+  for (int i = 0; i < argc; ++i)
+  {
+    if (*argv[i] == '-')
+    {
+      char c = *(argv[i] + 1);
+      switch (c)
+      {
+        case 'd':
+        {
+          isDebugMode_ = true;
+          break;
+        }
 
-				case 'f':
-				{
-					m_isFullscreen = true;
-					break;
-				}
+        case 'f':
+        {
+          isFullscreen_ = true;
+          break;
+        }
 
-				case 'w':
-				{
-					m_isSmallWindow = true;
-					break;
-				}
+        case 'w':
+        {
+          isSmallWindow_ = true;
+          break;
+        }
 
-				case 't':
-				{
-					const char* opt = getarg(argv[i]+2, (i < argc) ? argv[i+1] : NULL, i);
-					if (opt == NULL)
-					{
-						std::cerr << "error parsing arg -t\n";
-						break;
-					}
-					std::cerr << "arg t opt '" << opt << "'\n";
-					break;
-				}
-			}
-		}
-	}
+        case 't':
+        {
+          char const* opt = getarg(argv[i]+2, (i < argc) ? argv[i+1] : NULL, i);
+          if (opt == NULL)
+          {
+            std::cerr << "error parsing arg -t\n";
+            break;
+          }
+          std::cerr << "arg t opt '" << opt << "'\n";
+          break;
+        }
+      }
+    }
+  }
 }
 
 
@@ -119,78 +122,78 @@ NoDice::Config::
 bool NoDice::Config::
 isDebugMode() const
 {
-	return m_isDebugMode;
+  return isDebugMode_;
 }
 
 
 bool NoDice::Config::
 isFullscreen() const
 {
-	return m_isFullscreen;
+  return isFullscreen_;
 }
 
 
 bool NoDice::Config::
 isSmallWindow() const
 {
-	return m_isSmallWindow;
+  return isSmallWindow_;
 }
 
 
 int NoDice::Config::
 screenWidth() const
 {
-	return m_screenWidth;
+  return screenWidth_;
 }
 
 
 void NoDice::Config::
 setScreenWidth(int w)
 {
-	if (m_screenWidth != w)
-	{
-		m_screenWidth = w;
-		setDirty();
-	}
+  if (screenWidth_ != w)
+  {
+    screenWidth_ = w;
+    setDirty();
+  }
 }
 
 
 int NoDice::Config::
 screenHeight() const
 {
-	return m_screenHeight;
+  return screenHeight_;
 }
 
 
 void NoDice::Config::
 setScreenHeight(int h)
 {
-	if (m_screenHeight != h)
-	{
-		m_screenHeight = h;
-		setDirty();
-	}
+  if (screenHeight_ != h)
+  {
+    screenHeight_ = h;
+    setDirty();
+  }
 }
 
 
 int NoDice::Config::
 boardSize() const
-{ return m_boardSize; }
+{ return boardSize_; }
 
 
 void NoDice::Config::
 setBoardSize(int size)
 {
-	if (m_boardSize != size)
-	{
-		m_boardSize = size;
-		setDirty();
-	}
+  if (boardSize_ != size)
+  {
+    boardSize_ = size;
+    setDirty();
+  }
 }
 
 
 void NoDice::Config::
 setDirty()
 {
-	m_isDirty = true;
+  isDirty_ = true;
 }

--- a/nodice/config.cpp
+++ b/nodice/config.cpp
@@ -3,7 +3,7 @@
  * @brief Implemntation of the nodice/config module.
  */
 /*
- * Copyright 2009-2013 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ * Copyright 2009,2013,2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
  * This file is part of no-dice.
  *

--- a/nodice/config.h
+++ b/nodice/config.h
@@ -3,7 +3,7 @@
  * @brief Public interface of the nodice/config module.
  */
 /*
- * Copyright 2009-2013 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ * Copyright 2009,2013,2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
  * This file is part of no-dice.
  *

--- a/nodice/config.h
+++ b/nodice/config.h
@@ -1,24 +1,31 @@
 /**
  * @file nodice/config.h
  * @brief Public interface of the nodice/config module.
+ */
+/*
+ * Copyright 2009-2013 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
- * Copyright 2009, 2010 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ * This file is part of no-dice.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of Version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * No-dice is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef NODICE_CONFIG_H
 #define NODICE_CONFIG_H 1
+
+#include <string>
+#include <vector>
+
 
 namespace NoDice
 {
@@ -28,43 +35,60 @@ namespace NoDice
   class Config
   {
   public:
-	  /** Construcrs a Config object from command-line arguments. */
-	  Config(int argc, char* argv[]);
+    /** Construcrs a Config object from command-line arguments. */
+    Config(int argc, char* argv[]);
 
-	  /** Destroys a Config object. */
-	  ~Config();
+    /** Destroys a Config object. */
+    ~Config();
 
-		/** Indicates if debug mode is enabled. */
-		bool isDebugMode() const;
+    /** Indicates if debug mode is enabled. */
+    bool
+    isDebugMode() const;
 
-		/** Indicates if fullscreen mode is active. */
-		bool isFullscreen() const;
+    /** Indicates if fullscreen mode is active. */
+    bool
+    isFullscreen() const;
 
-		/** Indicates if (text mode) small window mode is set. */
-		bool isSmallWindow() const;
+    /** Indicates if (text mode) small window mode is set. */
+    bool
+    isSmallWindow() const;
 
-		/** Gets the currently selected screen width (in pixels). */
-		int  screenWidth() const;
-		void setScreenWidth(int w);
+    /** Gets the currently selected screen width (in pixels). */
+    int
+    screenWidth() const;
 
-		/** Gets the currently selected screen height (in pixels). */
-		int  screenHeight() const;
-		void setScreenHeight(int h);
+    /** Sets the current screen width (in pixels). */
+    void
+    setScreenWidth(int w);
 
-		int boardSize() const;
-		void setBoardSize(int size);
+    /** Gets the currently selected screen height (in pixels). */
+    int
+    screenHeight() const;
 
-	private:
-		void setDirty();
+    /** Sets the current screen height. */
+    void
+    setScreenHeight(int h);
 
-	private:
-		bool  m_isDirty;
-		bool  m_isDebugMode;
-		bool  m_isFullscreen;
-		bool  m_isSmallWindow;
-		int   m_screenWidth;
-		int   m_screenHeight;
-		int   m_boardSize;
+    /** Gets the board size (boards are always square). */
+    int
+    boardSize() const;
+
+    /** Sets the board size. */
+    void
+    setBoardSize(int size);
+
+  private:
+    void
+    setDirty();
+
+  private:
+    bool  isDirty_;
+    bool  isDebugMode_;
+    bool  isFullscreen_;
+    bool  isSmallWindow_;
+    int   screenWidth_;
+    int   screenHeight_;
+    int   boardSize_;
   };
 } // namespace NoDice
 

--- a/nodice/config.h
+++ b/nodice/config.h
@@ -43,39 +43,39 @@ namespace NoDice
 
     /** Indicates if debug mode is enabled. */
     bool
-    isDebugMode() const;
+    is_debug_mode() const;
 
     /** Indicates if fullscreen mode is active. */
     bool
-    isFullscreen() const;
+    is_fullscreen() const;
 
     /** Indicates if (text mode) small window mode is set. */
     bool
-    isSmallWindow() const;
+    is_small_window() const;
 
     /** Gets the currently selected screen width (in pixels). */
     int
-    screenWidth() const;
+    screen_width() const;
 
     /** Sets the current screen width (in pixels). */
     void
-    setScreenWidth(int w);
+    set_screen_width(int w);
 
     /** Gets the currently selected screen height (in pixels). */
     int
-    screenHeight() const;
+    screen_height() const;
 
     /** Sets the current screen height. */
     void
-    setScreenHeight(int h);
+    set_screen_height(int h);
 
     /** Gets the board size (boards are always square). */
     int
-    boardSize() const;
+    board_size() const;
 
     /** Sets the board size. */
     void
-    setBoardSize(int size);
+    set_board_size(int size);
 
     /** Gets the search path for assets. */
     std::vector<std::string> const&
@@ -83,16 +83,16 @@ namespace NoDice
 
   private:
     void
-    setDirty();
+    set_dirty();
 
   private:
-    bool                     isDirty_;
-    bool                     isDebugMode_;
-    bool                     isFullscreen_;
-    bool                     isSmallWindow_;
-    int                      screenWidth_;
-    int                      screenHeight_;
-    int                      boardSize_;
+    bool                     is_dirty_;
+    bool                     is_debug_mode_;
+    bool                     is_fullscreen_;
+    bool                     is_small_window_;
+    int                      screen_width_;
+    int                      screen_height_;
+    int                      board_size_;
     std::vector<std::string> asset_search_path_;
   };
 } // namespace NoDice

--- a/nodice/config.h
+++ b/nodice/config.h
@@ -77,18 +77,23 @@ namespace NoDice
     void
     setBoardSize(int size);
 
+    /** Gets the search path for assets. */
+    std::vector<std::string> const&
+    asset_search_path() const;
+
   private:
     void
     setDirty();
 
   private:
-    bool  isDirty_;
-    bool  isDebugMode_;
-    bool  isFullscreen_;
-    bool  isSmallWindow_;
-    int   screenWidth_;
-    int   screenHeight_;
-    int   boardSize_;
+    bool                     isDirty_;
+    bool                     isDebugMode_;
+    bool                     isFullscreen_;
+    bool                     isSmallWindow_;
+    int                      screenWidth_;
+    int                      screenHeight_;
+    int                      boardSize_;
+    std::vector<std::string> asset_search_path_;
   };
 } // namespace NoDice
 

--- a/nodice/font.cpp
+++ b/nodice/font.cpp
@@ -68,7 +68,9 @@ Font(const std::string& fontname, unsigned int pointsize)
 	ftStatus = FT_New_Face(ftLib, m_name.c_str(), 0, &ftFace);
 	if (ftStatus != 0)
 	{
-		throw std::runtime_error("error in FT_New_Face");
+                std::ostringstream ostr;
+		ostr << "error " << ftStatus << " in FT_New_Face(\"" << m_name << "\"";
+		throw std::runtime_error(ostr.str());
 	}
 
 	// munge character size.  Freetype uses 1/64th of a point (1/4608 of an inch)
@@ -329,45 +331,4 @@ print(GLfloat x, GLfloat y, GLfloat scale, const std::string& text)
 	glPopMatrix();
 }
 
-
-#ifndef DATA_DIR
-# define DATA_DIR "./"
-#endif
-
-/**
- * @param typefaceName[in]  Name of the typeface.
- * @param pointSize[in]     Size of the font in points.
- *
- * Checks the global font cache for the named font and returns a reference to
- * it.  If the font is not in the cache, it gets loaded first.
- */
-NoDice::Font& NoDice::
-getFont(const std::string& typefaceName, unsigned int pointSize)
-{
-  typedef std::map<std::string, Font> FontCache;
-  static FontCache s_fontCache;
-
-  std::ostringstream ostr;
-  ostr << typefaceName << '_' << pointSize;
-  std::string fontKey = ostr.str();
-  FontCache::iterator it = s_fontCache.find(fontKey);
-  if (it != s_fontCache.end())
-  {
-    return  it->second;
-  }
-
-  // allow in-build-directory to take precedence
-  std::string filename = "./assets/" + typefaceName + ".ttf";
-  if (0 != access(filename.c_str(), R_OK))
-  {
-    filename = DATA_DIR + std::string("/") + typefaceName + ".ttf";
-    if (0 != access(filename.c_str(), R_OK))
-    {
-      filename = typefaceName;
-    }
-  }
-  std::pair<FontCache::iterator,bool> p = s_fontCache.insert(
-                std::make_pair(fontKey, Font(filename, pointSize)));
-  return p.first->second;
-}
 

--- a/nodice/font.h
+++ b/nodice/font.h
@@ -66,9 +66,6 @@ namespace NoDice
 		GLsizei            m_textureHeight;
 		GLuint             m_texture;
 	};
-
-	/** Gets a font through the font loader/cache. */
-	Font& getFont(const std::string& fontName, unsigned int pointSize);
 } // namespace NoDice
 
 #endif // NODICE_FONT_H

--- a/nodice/fontcache.cpp
+++ b/nodice/fontcache.cpp
@@ -1,0 +1,94 @@
+#include <iostream>
+/**
+ * @file fontcache.cpp
+ * @brief Implementation of the nodice/fontcache module.
+ */
+/*
+ * Copyright 2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ *
+ * This file is part of no-dice.
+ *
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * No-dice is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "nodice_config.h"
+#include "nodice/fontcache.h"
+
+#include <algorithm>
+#include "nodice/config.h"
+#include "nodice/font.h"
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unistd.h>
+
+
+namespace
+{
+  std::string
+  font_key_for_typeface_and_size(std::string const& typeface, unsigned pointsize)
+  {
+    std::ostringstream ostr;
+    ostr << typeface << '_' << pointsize;
+    return ostr.str();
+  }
+
+  std::string
+  ttf_filename_for_typeface(std::string const& typeface)
+  {
+    return typeface + ".ttf";
+  }
+
+} // anonymous namespace
+
+
+NoDice::FontCache::
+FontCache(Config const* config)
+: config_(config)
+{ }
+
+
+NoDice::FontCache::
+~FontCache()
+{ }
+
+
+NoDice::Font& NoDice::FontCache::
+get_font(std::string const& typeface, unsigned pointsize)
+{
+  auto const& font_key = font_key_for_typeface_and_size(typeface, pointsize);
+  auto const& it = std::find_if(std::begin(cache_), std::end(cache_),
+                                [&font_key](Cache::value_type const& entry)
+                                {
+                                  return font_key == entry.name;
+                                });
+  if (it != std::end(cache_))
+  {
+    return *it->font;
+  }
+
+  auto const& ttf_filename = ttf_filename_for_typeface(typeface);
+  for (auto const& path: config_->asset_search_path())
+  {
+    std::string filename = path + "/" + ttf_filename;
+    if (0 == ::access(filename.c_str(), R_OK))
+    {
+      cache_.push_back(Cache::value_type{font_key, std::make_unique<Font>(filename, pointsize)});
+      return *cache_.back().font;
+    }
+  }
+
+  throw std::runtime_error("unable to find font '" + typeface + "'");
+}
+
+

--- a/nodice/fontcache.h
+++ b/nodice/fontcache.h
@@ -1,0 +1,72 @@
+/**
+ * @file fontcache.h
+ * @brief Public interface of the nodice/fontcache module.
+ */
+/*
+ * Copyright 2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ *
+ * This file is part of no-dice.
+ *
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * No-dice is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef NODICE_FONTCACHE_H
+#define NODICE_FONTCACHE_H 1
+
+#include <memory>
+#include <string>
+#include <vector>
+
+
+namespace NoDice
+{
+class Config;
+class Font;
+
+/**
+ * A cache of font objects.  If a requested font is not present in the cache, it
+ * gets loaded in from where fonts getr loaded in from.
+ */
+class FontCache
+{
+public:
+  FontCache(Config const* config);
+
+  ~FontCache();
+
+  /**
+   * Gets a font with a given typeface name and pointsize.
+   * @param[in] the name of the typeface
+   * @param[in] the pointsize of the font
+   */
+  Font&
+  get_font(std::string const& typeface, unsigned pointsize);
+
+private:
+  struct Entry
+  {
+    std::string           name;
+    std::unique_ptr<Font> font;
+  };
+
+  using Cache = std::vector<Entry>;
+
+private:
+  Config const*  config_;
+  Cache          cache_;
+};
+
+
+} // namespace NoDice
+
+#endif // NODICE_FONTCACHE_H

--- a/nodice/gamestate.cpp
+++ b/nodice/gamestate.cpp
@@ -26,8 +26,8 @@
 
 
 NoDice::GameState::
-GameState(Config const* config)
-: config_(config)
+GameState(NoDice::App* app)
+: app_(app)
 {
 }
 

--- a/nodice/gamestate.cpp
+++ b/nodice/gamestate.cpp
@@ -2,30 +2,32 @@
  * @file nodice/gamestate.cpp
  * @brief Implemntation of the NoDice gamestate module.
  *
- * Copyright 2010 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ * Copyright 2010,2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of Version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * This file is part of no-dice.
  *
- * This program is distributed in the hope that it will be useful,
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * No-dice is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "nodice_config.h"
-#include "gamestate.h"
+#include "nodice/gamestate.h"
 
 #include <iostream>
 
 
 NoDice::GameState::
-GameState(Config& config)
-: m_config(config)
+GameState(Config const* config)
+: config_(config)
 {
 }
 

--- a/nodice/gamestate.h
+++ b/nodice/gamestate.h
@@ -1,21 +1,25 @@
 /**
  * @file nodice/gamestate.h
  * @brief Public interface of the nodice/gamestate module.
+ */
+/*
+ * Copyright 2010,2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
- * Copyright 2010 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ * This file is part of no-dice.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of Version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * No-dice is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
+
  */
 #ifndef NODICE_GAMESTATE_H
 #define NODICE_GAMESTATE_H 1
@@ -44,7 +48,7 @@ namespace NoDice
 		};
 
 	public:
-		GameState(Config& config);
+		GameState(Config const* config);
 		virtual ~GameState() = 0;
 
 		virtual void pause();
@@ -58,7 +62,7 @@ namespace NoDice
 		virtual void draw(Video& video) = 0;
 
 	protected:
-		Config& m_config;
+		Config const* config_;
 	};
 
 	typedef std::tr1::shared_ptr<GameState> GameStatePtr;

--- a/nodice/gamestate.h
+++ b/nodice/gamestate.h
@@ -24,48 +24,47 @@
 #ifndef NODICE_GAMESTATE_H
 #define NODICE_GAMESTATE_H 1
 
-#include "nodice/config.h"
 #include <SDL/SDL_events.h>
-#include <tr1/memory>
+#include <memory>
 
 
 namespace NoDice
 {
-	class App;
-	class Video;
+  class App;
+  class Video;
 
-	/**
-	 * An abstract base class for things implementing a stateful part of the game.
-	 */
-	class GameState
-	{
-	public:
-		enum PointerAction
-		{
-			pointerUp,
-			pointerDown,
-			pointerDoubleDown
-		};
+  /**
+   * An abstract base class for things implementing a stateful part of the game.
+   */
+  class GameState
+  {
+  public:
+    enum PointerAction
+    {
+      pointerUp,
+      pointerDown,
+      pointerDoubleDown
+    };
 
-	public:
-		GameState(Config const* config);
-		virtual ~GameState() = 0;
+  public:
+    GameState(App* app);
+    virtual ~GameState() = 0;
 
-		virtual void pause();
-		virtual void resume();
+    virtual void pause();
+    virtual void resume();
 
-		virtual void key(SDL_keysym keysym);
-		virtual void pointerMove(int x, int y, int dx, int dy);
-		virtual void pointerClick(int x, int y, PointerAction action);
-		virtual void update(App& app) = 0;
+    virtual void key(SDL_keysym keysym);
+    virtual void pointerMove(int x, int y, int dx, int dy);
+    virtual void pointerClick(int x, int y, PointerAction action);
+    virtual void update(App& app) = 0;
 
-		virtual void draw(Video& video) = 0;
+    virtual void draw(Video& video) = 0;
 
-	protected:
-		Config const* config_;
-	};
+  protected:
+    App*  app_;
+  };
 
-	typedef std::tr1::shared_ptr<GameState> GameStatePtr;
+  typedef std::shared_ptr<GameState> GameStatePtr;
 
 } // namespace NoDice
 

--- a/nodice/introstate.cpp
+++ b/nodice/introstate.cpp
@@ -24,6 +24,7 @@
 #include "nodice/introstate.h"
 
 #include "nodice/app.h"
+#include "nodice/config.h"
 #include "nodice/font.h"
 #include "nodice/playstate.h"
 #include "nodice/video.h"
@@ -57,12 +58,12 @@ namespace
 
 
 NoDice::IntroState::
-IntroState(Config const* config,
+IntroState(NoDice::App*  app,
            Video const&  video NODICE_UNUSED)
-: GameState(config)
+: GameState(app)
 , is_active_(true)
-, menu_font_(getFont(MENU_FONT, config->screen_height() / 18))
-, title_pos_(0.25 * config->screen_width(), 0.75 * config->screen_height())
+, menu_font_(app_->font_cache().get_font(MENU_FONT, app_->config().screen_height() / 18))
+, title_pos_(0.25 * app_->config().screen_width(), 0.75 * app_->config().screen_height())
 , selected_(0)
 , next_state_(next_state_same)
 {
@@ -156,11 +157,11 @@ update(App& app)
   switch (next_state_)
   {
     case next_state_quit:
-      app.popGameState();
+      app.pop_game_state();
       break;
 
     case next_state_play:
-      app.pushGameState(GameStatePtr(new PlayState(config_)));
+      app.push_game_state(GameStatePtr(new PlayState(app_)));
       break;
 
     default:

--- a/nodice/introstate.cpp
+++ b/nodice/introstate.cpp
@@ -1,21 +1,24 @@
 /**
  * @file introstate.cpp
  * @brief Implemntation of the introstate module.
- *
+ */
+/*
  * Copyright 2010 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of Version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * This file is part of no-dice.
  *
- * This program is distributed in the hope that it will be useful,
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * No-dice is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "nodice_config.h"
 #include "nodice/introstate.h"
@@ -30,45 +33,45 @@
 
 namespace 
 {
-	struct MenuEntry
-	{
-		const char*                    title;
-		vmml::Vector2f                 pos;
-		NoDice::IntroState::NextState  nextState;
-	};
+  struct MenuEntry
+  {
+    const char*                    title;
+    vmml::Vector2f                 pos;
+    NoDice::IntroState::NextState  nextState;
+  };
 
-	static MenuEntry entry[] = 
-	{
-		{ "options", vmml::Vector2f(0.0f, 0.0f), NoDice::IntroState::next_state_options },
-		{ "play",    vmml::Vector2f(0.0f, 0.0f), NoDice::IntroState::next_state_play },
-		{ "quit",    vmml::Vector2f(0.0f, 0.0f), NoDice::IntroState::next_state_quit }
-	};
+  static MenuEntry entry[] = 
+  {
+    { "options", vmml::Vector2f(0.0f, 0.0f), NoDice::IntroState::next_state_options },
+    { "play",    vmml::Vector2f(0.0f, 0.0f), NoDice::IntroState::next_state_play },
+    { "quit",    vmml::Vector2f(0.0f, 0.0f), NoDice::IntroState::next_state_quit }
+  };
 
-	static const std::size_t menuCount = sizeof(entry) / sizeof(MenuEntry);
+  static const std::size_t menuCount = sizeof(entry) / sizeof(MenuEntry);
 
-	static float titleColour[] = { 1.00f, 0.10f, 0.10f, 1.00f };
-	static float selectedColour[] = { 0.80f, 0.50f, 1.00f, 0.80f };
-	static float unselectedColour[] = { 0.20f, 0.20f, 0.80f, 0.80f };
+  static float titleColour[] = { 1.00f, 0.10f, 0.10f, 1.00f };
+  static float selectedColour[] = { 0.80f, 0.50f, 1.00f, 0.80f };
+  static float unselectedColour[] = { 0.20f, 0.20f, 0.80f, 0.80f };
 
 } // anonymous namespace
 
 
 NoDice::IntroState::
-IntroState(Config& config,
-           const Video& video NODICE_UNUSED)
+IntroState(Config const* config,
+           Video const&  video NODICE_UNUSED)
 : GameState(config)
-, m_isActive(true)
-, m_menuFont(getFont(MENU_FONT, config.screenHeight() / 18))
-, m_titlePos(0.25 * config.screenWidth(), 0.75 * config.screenHeight())
-, m_selected(0)
-, m_nextState(next_state_same)
+, is_active_(true)
+, menu_font_(getFont(MENU_FONT, config->screen_height() / 18))
+, title_pos_(0.25 * config->screen_width(), 0.75 * config->screen_height())
+, selected_(0)
+, next_state_(next_state_same)
 {
-	const float vspacing = -2.0f * m_menuFont.height();
-	entry[0].pos.set(m_titlePos.x, m_titlePos.y + vspacing);
-	for (std::size_t i = 1; i < menuCount; ++i)
-	{
-		entry[i].pos.set(entry[i-1].pos.x, entry[i-1].pos.y + vspacing);
-	}
+  const float vspacing = -2.0f * menu_font_.height();
+  entry[0].pos.set(title_pos_.x, title_pos_.y + vspacing);
+  for (std::size_t i = 1; i < menuCount; ++i)
+  {
+    entry[i].pos.set(entry[i-1].pos.x, entry[i-1].pos.y + vspacing);
+  }
 }
 
 NoDice::IntroState::
@@ -79,54 +82,54 @@ NoDice::IntroState::
 void NoDice::IntroState::
 pause()
 {
-	m_isActive = false;
+  is_active_ = false;
 }
 
 
 void NoDice::IntroState::
 resume()
 {
-	m_isActive = true;
+  is_active_ = true;
 }
 
 
 void NoDice::IntroState::
 key(SDL_keysym keysym)
 {
-	switch (keysym.sym)
-	{
-		case SDLK_UP:
-			--m_selected;
-			if (m_selected < 0)
-				m_selected = 0;
-			break;
+  switch (keysym.sym)
+  {
+    case SDLK_UP:
+      --selected_;
+      if (selected_ < 0)
+        selected_ = 0;
+      break;
 
-		case SDLK_DOWN:
-			++m_selected;
-			if (std::size_t(m_selected) >= menuCount)
-				m_selected = menuCount-1;
-			break;
+    case SDLK_DOWN:
+      ++selected_;
+      if (std::size_t(selected_) >= menuCount)
+        selected_ = menuCount-1;
+      break;
 
-		case SDLK_RETURN:
-		case SDLK_KP_ENTER:
-			m_nextState = entry[m_selected].nextState;
-			break;
+    case SDLK_RETURN:
+    case SDLK_KP_ENTER:
+      next_state_ = entry[selected_].nextState;
+      break;
 
-		case SDLK_o:
-			m_nextState = next_state_options;
-			break;
+    case SDLK_o:
+      next_state_ = next_state_options;
+      break;
 
-		case SDLK_p:
-			m_nextState = next_state_play;
-			break;
+    case SDLK_p:
+      next_state_ = next_state_play;
+      break;
 
-		case SDLK_q:
-			m_nextState = next_state_quit;
-			break;
+    case SDLK_q:
+      next_state_ = next_state_quit;
+      break;
 
-	        default:
-	                break;
-	}
+          default:
+                  break;
+  }
 }
 
 
@@ -150,36 +153,36 @@ pointerClick(int x NODICE_UNUSED,
 void NoDice::IntroState::
 update(App& app)
 {
-	switch (m_nextState)
-	{
-		case next_state_quit:
-			app.popGameState();
-			break;
+  switch (next_state_)
+  {
+    case next_state_quit:
+      app.popGameState();
+      break;
 
-		case next_state_play:
-			app.pushGameState(GameStatePtr(new PlayState(m_config)));
-			break;
+    case next_state_play:
+      app.pushGameState(GameStatePtr(new PlayState(config_)));
+      break;
 
-		default:
-			break;
-	}
+    default:
+      break;
+  }
 }
 
 
 void NoDice::IntroState::
 draw(Video& video NODICE_UNUSED)
 {
-	glColor4fv(titleColour);
-	m_menuFont.print(m_titlePos.x, m_titlePos.y, 1.0f, "No Dice!");
+  glColor4fv(titleColour);
+  menu_font_.print(title_pos_.x, title_pos_.y, 1.0f, "No Dice!");
 
-	for (std::size_t i = 0; i < menuCount; ++i)
-	{
-		if (i == std::size_t(m_selected))
-			glColor4fv(selectedColour);
-		else
-			glColor4fv(unselectedColour);
-		m_menuFont.print(entry[i].pos.x, entry[i].pos.y, 1.0f, entry[i].title);
-	}
+  for (std::size_t i = 0; i < menuCount; ++i)
+  {
+    if (i == std::size_t(selected_))
+      glColor4fv(selectedColour);
+    else
+      glColor4fv(unselectedColour);
+    menu_font_.print(entry[i].pos.x, entry[i].pos.y, 1.0f, entry[i].title);
+  }
 }
 
 

--- a/nodice/introstate.h
+++ b/nodice/introstate.h
@@ -29,45 +29,45 @@
 
 namespace NoDice
 {
-	class Font;
+  class Font;
 
-	/**
-	 * Provides the "game introduction" state:  mostly just the loading screen.
-	 */
-	class IntroState
-	: public GameState
-	{
-	public:
-		enum NextState
-		{
-			next_state_same,
-			next_state_options,
-			next_state_play,
-			next_state_quit
-		};
+  /**
+   * Provides the "game introduction" state:  mostly just the loading screen.
+   */
+  class IntroState
+  : public GameState
+  {
+  public:
+    enum NextState
+    {
+      next_state_same,
+      next_state_options,
+      next_state_play,
+      next_state_quit
+    };
 
-	public:
-		IntroState(Config const* config, const Video& video);
+  public:
+    IntroState(App* app, const Video& video);
 
-		~IntroState();
+    ~IntroState();
 
-		void pause();
-		void resume();
+    void pause();
+    void resume();
 
-		void key(SDL_keysym keysym);
-		void pointerMove(int x, int y, int dx, int dy);
-		void pointerClick(int x, int y, PointerAction action);
-		void update(App& app);
+    void key(SDL_keysym keysym);
+    void pointerMove(int x, int y, int dx, int dy);
+    void pointerClick(int x, int y, PointerAction action);
+    void update(App& app);
 
-		void draw(Video& video);
+    void draw(Video& video);
 
-	private:
-		bool       is_active_;
-		Font&      menu_font_;
-		Vector2f   title_pos_;
-		int        selected_;
-		NextState  next_state_;
-	};
+  private:
+    bool       is_active_;
+    Font&      menu_font_;
+    Vector2f   title_pos_;
+    int        selected_;
+    NextState  next_state_;
+  };
 
 } // namespace NoDice
 

--- a/nodice/introstate.h
+++ b/nodice/introstate.h
@@ -1,21 +1,24 @@
 /**
  * @file introstate.h
  * @brief Public interface of the introstate module.
- *
+ */
+/*
  * Copyright 2010 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of Version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * This file is part of no-dice.
  *
- * This program is distributed in the hope that it will be useful,
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * No-dice is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef IntroState_H
 #define IntroState_H 1
@@ -44,7 +47,7 @@ namespace NoDice
 		};
 
 	public:
-		IntroState(Config& config, const Video& video);
+		IntroState(Config const* config, const Video& video);
 
 		~IntroState();
 
@@ -59,11 +62,11 @@ namespace NoDice
 		void draw(Video& video);
 
 	private:
-		bool       m_isActive;
-		Font&      m_menuFont;
-		Vector2f   m_titlePos;
-		int        m_selected;
-		NextState  m_nextState;
+		bool       is_active_;
+		Font&      menu_font_;
+		Vector2f   title_pos_;
+		int        selected_;
+		NextState  next_state_;
 	};
 
 } // namespace NoDice

--- a/nodice/main.cpp
+++ b/nodice/main.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[])
 	{
 		std::cerr << PACKAGE_STRING << "\n";
 		Config config(argc, argv);
-		return NoDice::App(config).run();
+		return NoDice::App(&config).run();
 
 	}
 	catch (std::exception& ex)

--- a/nodice/playstate.cpp
+++ b/nodice/playstate.cpp
@@ -26,7 +26,9 @@
 #include <iomanip>
 #include <iostream>
 #include <sstream>
+#include "nodice/app.h"
 #include "nodice/colour.h"
+#include "nodice/config.h"
 #include "nodice/font.h"
 #include "nodice/object.h"
 #include "nodice/shape.h"
@@ -50,11 +52,11 @@ namespace
 
 
 NoDice::PlayState::
-PlayState(Config const* config)
-: GameState(config)
+PlayState(App* app)
+: GameState(app)
 , state_(state_idle)
-, gameboard_(config)
-, score_font_(getFont(SCORE_FONT, config->screen_height() / 18))
+, gameboard_(&app_->config())
+, score_font_(app_->font_cache().get_font(SCORE_FONT, app_->config().screen_height() / 18))
 , mouse_is_down_(false)
 , multiplier_(0)
 , score_(0)
@@ -63,8 +65,8 @@ PlayState(Config const* config)
   glMatrixMode(GL_PROJECTION);
   glPushMatrix();
   glLoadIdentity();
-  int w = config->screen_width();
-  int h = config->screen_height();
+  int w = app_->config().screen_width();
+  int h = app_->config().screen_height();
   float right = 1.0f;
   float top   = 1.0f;
   if (h < w)
@@ -112,7 +114,7 @@ pointerMove(int x, int y, int dx, int dy)
     {
       if (dx < 0 && selected_pos_.x > 0)
           --pos2.x;
-      else if (selected_pos_.x < config_->board_size()-1)
+      else if (selected_pos_.x < app_->config().board_size()-1)
           ++pos2.x;
       else
         return;
@@ -121,7 +123,7 @@ pointerMove(int x, int y, int dx, int dy)
     {
       if (dy > 0 && selected_pos_.y > 0)
           --pos2.y;
-      else if (selected_pos_.y < config_->board_size()-1)
+      else if (selected_pos_.y < app_->config().board_size()-1)
           ++pos2.y;
       else
         return;
@@ -143,8 +145,8 @@ pointerClick(int x, int y, PointerAction action)
   else if (action == pointerDown)
   {
     mouse_down_pos_.set(x, y);
-    float win_width = float(config_->screen_width()) / 2.0f;
-    float win_height = float(config_->screen_height()) / 2.0f;
+    float win_width = float(app_->config().screen_width()) / 2.0f;
+    float win_height = float(app_->config().screen_height()) / 2.0f;
     float unit_x = float(x - win_width) / win_width;
     float unit_y = -float(y - win_height) / win_height;
 
@@ -152,9 +154,9 @@ pointerClick(int x, int y, PointerAction action)
     Vector4f beam = unproject_ * ray;
     selected_pos_.x = int(beam.x / 2.0f + 0.50f);
     selected_pos_.y = int(beam.y / 2.0f + 0.50f);
-    if (selected_pos_.x >= config_->board_size() || selected_pos_.x < 0)
+    if (selected_pos_.x >= app_->config().board_size() || selected_pos_.x < 0)
       return;
-    if (selected_pos_.y >= config_->board_size() || selected_pos_.y < 0)
+    if (selected_pos_.y >= app_->config().board_size() || selected_pos_.y < 0)
       return;
 
     ObjectPtr obj = gameboard_.at(selected_pos_.x, selected_pos_.y);
@@ -262,8 +264,8 @@ draw(Video& video NODICE_UNUSED)
   glLoadIdentity();
 
   // Adjust projection to take aspect ratio into account.
-  int w = config_->screen_width();
-  int h = config_->screen_height();
+  int w = app_->config().screen_width();
+  int h = app_->config().screen_height();
   float right = 1.0f;
   float top   = 1.0f;
   if (h < w)

--- a/nodice/playstate.h
+++ b/nodice/playstate.h
@@ -1,21 +1,24 @@
 /**
  * @file nodice/playstate.h
  * @brief Public interface of the nodice/playstate module.
+ */
+/*
+ * Copyright 2010,2011,2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
- * Copyright 2010, 2011 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ * This file is part of no-dice.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of Version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * No-dice is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef NODICE_PLAYSTATE_H
 #define NODICE_PLAYSTATE_H 1
@@ -36,7 +39,7 @@ namespace NoDice
   : public GameState
   {
   public:
-    PlayState(Config& config);
+    PlayState(Config const* config);
     ~PlayState();
 
     void pointerMove(int x, int y, int dx, int dy);
@@ -59,16 +62,16 @@ namespace NoDice
       state_end
     };
 
-    SubState                  m_state;
-    Board                     m_gameboard;
-    Font&                     m_scoreFont;
-    bool                      m_mouseIsDown;
-    Vector2i                  m_mouseDownPos;
-    Vector2i                  m_selectedPos;
-    int                       m_multiplier;
-    int                       m_score;
-    std::vector<std::string>  m_winMessages;
-    Matrix4f                  m_unproject;
+    SubState                  state_;
+    Board                     gameboard_;
+    Font&                     score_font_;
+    bool                      mouse_is_down_;
+    Vector2i                  mouse_down_pos_;
+    Vector2i                  selected_pos_;
+    int                       multiplier_;
+    int                       score_;
+    std::vector<std::string>  win_messages_;
+    Matrix4f                  unproject_;
   };
 
 } // namespace noDice

--- a/nodice/playstate.h
+++ b/nodice/playstate.h
@@ -39,7 +39,7 @@ namespace NoDice
   : public GameState
   {
   public:
-    PlayState(Config const* config);
+    PlayState(App* app);
     ~PlayState();
 
     void pointerMove(int x, int y, int dx, int dy);

--- a/nodice/video.cpp
+++ b/nodice/video.cpp
@@ -1,21 +1,24 @@
 /**
  * @file nodice/video.cpp
  * @brief Implemntation of the nodice/video module.
+ */
+/*
+ * Copyright 2009,2010,2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
- * Copyright 2009, 2010 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ * This file is part of no-dice.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of Version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * No-dice is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "nodice/video.h"
 
@@ -29,37 +32,37 @@
 
 namespace
 {
-	void initGL()
-	{
-		initGlVboExtension();
+  void initGL()
+  {
+    initGlVboExtension();
 
-		glShadeModel(GL_SMOOTH);
-		glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glShadeModel(GL_SMOOTH);
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 #ifdef HAVE_OPENGL_ES
-		glClearDepthf(1.0f);
+    glClearDepthf(1.0f);
 #else
-		glClearDepth(1.0f);
+    glClearDepth(1.0f);
 #endif
-		glEnable(GL_DEPTH_TEST);
-		glDepthFunc(GL_EQUAL);
-		glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
-	}
+    glEnable(GL_DEPTH_TEST);
+    glDepthFunc(GL_EQUAL);
+    glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST);
+  }
 }
 
 NoDice::Video::
-Video(Config& config)
+Video(Config const* config)
 #ifdef HAVE_EGL
-: m_context(new VideoContextEGL(config))
+: m_context(new VideoContextEGL(*config))
 #else
 : m_context(new VideoContextSDL(config))
 #endif
 {
-	initGL();
-	glViewport(0, 0, config.screenWidth(), config.screenHeight());
-	glMatrixMode(GL_PROJECTION);
-	glLoadIdentity();
-	glMatrixMode(GL_MODELVIEW);
-	glLoadIdentity();
+  initGL();
+  glViewport(0, 0, config->screen_width(), config->screen_height());
+  glMatrixMode(GL_PROJECTION);
+  glLoadIdentity();
+  glMatrixMode(GL_MODELVIEW);
+  glLoadIdentity();
 }
 
 
@@ -72,10 +75,10 @@ NoDice::Video::
 void NoDice::Video::
 update()
 {
-	m_context->swapBuffers();
-	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-	glLoadIdentity();
-	glTranslatef(0.0f, 0.0f, -1.0f);
+  m_context->swapBuffers();
+  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+  glLoadIdentity();
+  glTranslatef(0.0f, 0.0f, -1.0f);
 }
 
 

--- a/nodice/video.h
+++ b/nodice/video.h
@@ -32,7 +32,7 @@ namespace NoDice
   class Video
   {
   public:
-    Video(Config& config);
+    Video(Config const* config);
     ~Video();
 
     void update();

--- a/nodice/videocontext.h
+++ b/nodice/videocontext.h
@@ -1,48 +1,55 @@
 /**
- * @file nodice/videocontext/g.h
+ * @file nodice/videocontext.h
  * @brief Public interface of the nodice/videocontext/g module.
+ */
+/*
+ * Copyright 2009,2010,2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
- * Copyright 2009, 2010 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ * This file is part of no-dice.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of Version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * No-dice is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef NODICE_VIDEOCONTEXT_H
 #define NODICE_VIDEOCONTEXT_H 1
 
 namespace NoDice
 {
-	/**
-	 * A base class for the various platform-specific video contexts.
-	 */
-	class VideoContext
-	{
-	public:
-		VideoContext()
-		: m_depth(32)
-		{ }
+  /**
+   * A base class for the various platform-specific video contexts.
+   */
+  class VideoContext
+  {
+  public:
+    VideoContext()
+    : depth_(32)
+    { }
 
-		virtual ~VideoContext()
-		{ }
+    virtual
+    ~VideoContext()
+    { }
 
 
-		virtual void swapBuffers() = 0;
+    virtual void
+    swapBuffers() = 0;
 
-		int depth()  const { return m_depth; }
+    int
+    depth() const
+    { return depth_; }
 
-	protected:
-		int m_depth;
-	};
+  protected:
+    int depth_;
+  };
 } // namespace NoDice
 
 #endif // NODICE_VIDEOCONTEXT_H

--- a/nodice/videocontextsdl.cpp
+++ b/nodice/videocontextsdl.cpp
@@ -1,21 +1,24 @@
 /**
  * @file nodice/videocontextsdl.cpp
  * @brief Implemntation of the nodice/videocontextsdl module.
+ */
+/*
+ * Copyright 2009,2010,2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
- * Copyright 2009, 2010 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ * This file is part of no-dice.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of Version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * No-dice is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "nodice/videocontextsdl.h"
 
@@ -25,118 +28,120 @@
 
 
 NoDice::VideoContextSDL::
-VideoContextSDL(Config& config)
+VideoContextSDL(Config const* config)
 {
-	if (0 != ::SDL_InitSubSystem(SDL_INIT_VIDEO))
-	{
-		std::cerr << "*** ERRROR in SDL_InitSubSystem(SDL_INIT_VIDEO): "
-		          << ::SDL_GetError() << "\n";
-		exit(1);
-	}
+  if (0 != ::SDL_InitSubSystem(SDL_INIT_VIDEO))
+  {
+    std::cerr << "*** ERRROR in SDL_InitSubSystem(SDL_INIT_VIDEO): "
+              << ::SDL_GetError() << "\n";
+    exit(1);
+  }
 
-	SDL_GL_SetAttribute(SDL_GL_RED_SIZE,     5);
+  SDL_GL_SetAttribute(SDL_GL_RED_SIZE,     5);
   SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE,   5);
   SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE,    5);
   SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE,  16);
   SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
-	const SDL_VideoInfo* videoInfo = SDL_GetVideoInfo();
-	if (!videoInfo)
-	{
-		std::cerr << "*** ERRROR in SDL_GetVideoInfo(): "
-		          << ::SDL_GetError() << "\n";
-		exit(1);
-	}
-	if (config.isDebugMode())
-		std::cerr << "Video Info:\n"
-		          << "  current_w=" << videoInfo->current_w << "\n"
-		          << "  current_h=" << videoInfo->current_h << "\n"
-		          << "  vfmt->BitsPerPixel="
-		          << static_cast<int>(videoInfo->vfmt->BitsPerPixel) << "\n";
+  const SDL_VideoInfo* videoInfo = SDL_GetVideoInfo();
+  if (!videoInfo)
+  {
+    std::cerr << "*** ERRROR in SDL_GetVideoInfo(): "
+              << ::SDL_GetError() << "\n";
+    exit(1);
+  }
+  if (config->is_debug_mode())
+    std::cerr << "Video Info:\n"
+              << "  current_w=" << videoInfo->current_w << "\n"
+              << "  current_h=" << videoInfo->current_h << "\n"
+              << "  vfmt->BitsPerPixel="
+              << static_cast<int>(videoInfo->vfmt->BitsPerPixel) << "\n";
 
-	SDL_Rect** modes = SDL_ListModes(videoInfo->vfmt, SDL_OPENGL|SDL_FULLSCREEN);
-//	SDL_Rect** modes = SDL_ListModes(videoInfo->vfmt, SDL_OPENGL);
-	if (modes == NULL)
-	{
-		std::cerr << "*** ERRROR no supported video modes available.\n";
-		exit(1);
-	}
+  SDL_Rect** modes = SDL_ListModes(videoInfo->vfmt, SDL_OPENGL|SDL_FULLSCREEN);
+//  SDL_Rect** modes = SDL_ListModes(videoInfo->vfmt, SDL_OPENGL);
+  if (modes == NULL)
+  {
+    std::cerr << "*** ERRROR no supported video modes available.\n";
+    exit(1);
+  }
 
-	int width = config.isFullscreen() ? videoInfo->current_w : config.screenWidth();
-	int height = config.isFullscreen() ? videoInfo->current_h : config.screenHeight();
-	if (modes == (SDL_Rect **)-1)
-	{
-		std::cerr << "==smw> all video resolutions available.\n";
-	}
-	else
-	{
-		if (config.isDebugMode())
-		{
-			std::cerr << "Available Modes:\n";
-			for (int i=0; modes[i]; ++i)
-			{
-				std::cerr << "  " << modes[i]->w << "x" << modes[i]->h << "\n";
-			}
-		}
+  int width = config->is_fullscreen() ? videoInfo->current_w : config->screen_width();
+  int height = config->is_fullscreen() ? videoInfo->current_h : config->screen_height();
+  if (modes == (SDL_Rect **)-1)
+  {
+    std::cerr << "==smw> all video resolutions available.\n";
+  }
+  else
+  {
+    if (config->is_debug_mode())
+    {
+      std::cerr << "Available Modes:\n";
+      for (int i=0; modes[i]; ++i)
+      {
+        std::cerr << "  " << modes[i]->w << "x" << modes[i]->h << "\n";
+      }
+    }
 
-		bool mode_found = false;
-		for (int i=0; modes[i]; ++i)
-		{
-			if (modes[i]->w == width && modes[i]->h == height)
-			{
-				mode_found = true;
-				break;
-			}
-		}
-		if (!mode_found && modes[0])
-		{
-			if (config.isDebugMode())
-				std::cerr << ".. mode " << width << "x" << height
-				          << "not found, falling back to default.\n";
-			if (config.isSmallWindow())
-			{
-				width = 640;
-				height = 480;
-			}
-			else
-			{
-				width = modes[0]->w;
-				height = modes[0]->h;
-			}
-		}
-	}
-	if (config.isDebugMode())
-		std::cerr << ".. choosing window size " << width
-				<< "x" << height
-				<< "x" << static_cast<int>(videoInfo->vfmt->BitsPerPixel) << ".\n";
+    bool mode_found = false;
+    for (int i=0; modes[i]; ++i)
+    {
+      if (modes[i]->w == width && modes[i]->h == height)
+      {
+        mode_found = true;
+        break;
+      }
+    }
+    if (!mode_found && modes[0])
+    {
+      if (config->is_debug_mode())
+        std::cerr << ".. mode " << width << "x" << height
+                  << "not found, falling back to default.\n";
+      if (config->is_small_window())
+      {
+        width = 640;
+        height = 480;
+      }
+      else
+      {
+        width = modes[0]->w;
+        height = modes[0]->h;
+      }
+    }
+  }
+  if (config->is_debug_mode())
+    std::cerr << ".. choosing window size " << width
+        << "x" << height
+        << "x" << static_cast<int>(videoInfo->vfmt->BitsPerPixel) << ".\n";
 
-	Uint32 videoFlags = SDL_OPENGL | SDL_GL_DOUBLEBUFFER;
-	if (config.isFullscreen())
-	{
-		if (config.isDebugMode())
-			std::cerr << ".. choosing full-screen mode\n";
-		videoFlags |= SDL_FULLSCREEN;
-	}
-	else if (config.isDebugMode())
-	{
-		std::cerr << ".. choosing windowed mode\n";
-	}
+  Uint32 videoFlags = SDL_OPENGL | SDL_GL_DOUBLEBUFFER;
+  if (config->is_fullscreen())
+  {
+    if (config->is_debug_mode())
+      std::cerr << ".. choosing full-screen mode\n";
+    videoFlags |= SDL_FULLSCREEN;
+  }
+  else if (config->is_debug_mode())
+  {
+    std::cerr << ".. choosing windowed mode\n";
+  }
 
-	SDL_Surface* surface = SDL_SetVideoMode(width, height, videoInfo->vfmt->BitsPerPixel, videoFlags);
-	if (!surface)
-	{
-		std::cerr << "*** ERRROR in SDL_SetVideoMode(): " << ::SDL_GetError() << "\n";
-		exit(1);
-	}
+  SDL_Surface* surface = SDL_SetVideoMode(width, height, videoInfo->vfmt->BitsPerPixel, videoFlags);
+  if (!surface)
+  {
+    std::cerr << "*** ERRROR in SDL_SetVideoMode(): " << ::SDL_GetError() << "\n";
+    exit(1);
+  }
 
-	videoInfo = SDL_GetVideoInfo();
-	config.setScreenWidth(videoInfo->current_w);
-	config.setScreenHeight(videoInfo->current_h);
+  videoInfo = SDL_GetVideoInfo();
+#if 0
+  config->setScreenWidth(videoInfo->current_w);
+  config->setScreenHeight(videoInfo->current_h);
+#endif
 }
 
 void NoDice::VideoContextSDL::swapBuffers()
 {
-	SDL_GL_SwapBuffers();
+  SDL_GL_SwapBuffers();
 }
 
 

--- a/nodice/videocontextsdl.h
+++ b/nodice/videocontextsdl.h
@@ -1,21 +1,24 @@
 /**
  * @file nodice/videocontextsdl.h
  * @brief Public interface of the nodice/videocontextsdl module.
+ */
+/*
+ * Copyright 2009,2010,2017 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
  *
- * Copyright 2009, 2010 Stephen M. Webb  <stephen.webb@bregmasoft.ca>
+ * This file is part of no-dice.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of Version 2 of the GNU General Public License as
- * published by the Free Software Foundation.
+ * No-dice is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful,
+ * No-dice is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ * along with no-dice.  If not, see <http://www.gnu.org/licenses/>.
  */
 #ifndef NODICE_VIDEOCONTEXTSDL_H
 #define NODICE_VIDEOCONTEXTSDL_H 1
@@ -25,17 +28,18 @@
 
 namespace NoDice
 {
-	class Config;
+  class Config;
 
 
-	class VideoContextSDL
-	: public VideoContext
-	{
-	public:
-		VideoContextSDL(Config& config);
+  class VideoContextSDL
+  : public VideoContext
+  {
+  public:
+    VideoContextSDL(Config const* config);
 
-		void swapBuffers();
-	};
+    void
+    swapBuffers() override;
+  };
 
 } // namespace NoDice
 

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -30,9 +30,9 @@ SCENARIO("basic command line options handling")
     NoDice::Config config(argc, argv);
     THEN("sensible defaults are set")
     {
-      REQUIRE(config.isDebugMode() == false);
-      REQUIRE(config.isFullscreen() == false);
-      REQUIRE(config.boardSize() == 8);
+      REQUIRE(config.is_debug_mode() == false);
+      REQUIRE(config.is_fullscreen() == false);
+      REQUIRE(config.board_size() == 8);
     }
   }
 
@@ -43,7 +43,7 @@ SCENARIO("basic command line options handling")
     NoDice::Config config(argc, argv);
     THEN("debug mode is configured")
     {
-      REQUIRE(config.isDebugMode() == true);
+      REQUIRE(config.is_debug_mode() == true);
     }
   }
 
@@ -54,7 +54,7 @@ SCENARIO("basic command line options handling")
     NoDice::Config config(argc, argv);
     THEN("full-screen mode is configured")
     {
-      REQUIRE(config.isFullscreen() == true);
+      REQUIRE(config.is_fullscreen() == true);
     }
   }
 }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -59,3 +59,19 @@ SCENARIO("basic command line options handling")
   }
 }
 
+
+SCENARIO("asset searching")
+{
+  GIVEN("a default-constructed Config")
+  {
+    char* argv[] = { (char*)"no-dice" };
+    int argc = sizeof(argv) / sizeof(char*);
+    NoDice::Config config(argc, argv);
+
+    THEN("the asset search path containts at least one item")
+    {
+      REQUIRE(config.asset_search_path().size() > 0);
+    }
+  }
+}
+


### PR DESCRIPTION
Provide a rudimentary search path for assets.

Also refactors font cache into its own class to take advantage of the asset search path, and propagates global cache objects into game objects via the App class.

Closes issue #4.